### PR TITLE
Allow alternate db config to be partial, address #3

### DIFF
--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -46,7 +46,7 @@ module Biran
         File.join(app_shared_dir, configuration.config_dirname, configuration.local_config_filename)
     end
 
-    def alt_db_config_file
+    def db_config_override_file
       File.join(app_shared_dir, configuration.config_dirname, configuration.db_config_filename)
     end
 

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -61,13 +61,12 @@ module Biran
 
     def build_db_config
       default_db_config = base_db_config
-      return default_db_config unless File.exist? alt_db_config_file
-      default_db_config.deep_merge! process_config_file(alt_db_config_file)
+      return default_db_config unless File.exist? db_config_override_file
+      default_db_config.deep_merge! process_config_file(db_config_override_file)
     end
 
     def base_db_config
-      return @base_db_config if @base_db_config
-      @base_db_config = process_config_file(default_db_config_file)
+      @base_db_config ||= process_config_file(default_db_config_file)
     end
 
     def app_config_defaults


### PR DESCRIPTION
- The alternate db_config.yml file is now merged instead of needing to be a complete copy of all values