### PR TITLE
Refactor and namespace env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Config file example:
 ```
 defaults: &defaults
   app: &app_defaults
-    root_path: <%= Rails.root %>
+    base_path: <%= Rails.root %>
     use_capistrano: false
     bindings:
       - db_config
@@ -43,14 +43,14 @@ staging:
   <<: *defaults
   app:
     <<: *app_defaults
-    root_path: '/srv/my_app'
+    base_path: '/srv/my_app'
     use_capistrano: true
 
 production:
   <<: *defaults
   app:
     <<: *app_defaults
-    root_path: '/srv/my_app'
+    base_path: '/srv/my_app'
     use_capistrano: true
   vhost:
     <<: *vhost_defaults
@@ -72,7 +72,7 @@ the list of things you can configure are:
 :db_config_file_name,
 :secrets_filename,
 :config_dirname,
-:root_path,
+:base_path,
 :shared_dir,
 :use_capistrano,
 :db_config,
@@ -130,12 +130,12 @@ Available in: initializer**
 
 Generally no need to change, but here in case you want to change the default of where templates and generated config files are stored.
 
-### root_path
+### base_path
 **Type: string  
 Default: Rails.root in rails apps, ‘./’ in others  
 Available in: environment variable, config file, initializer**
 
-Biran assumes you will be using `Rails.root` in dev of course and will use that value unless something else is specified. If using capistrano, you will want to define the root_path not including `current`. Biran will use this path to find the shared dir and the local config dir used to override any values.
+Biran assumes you will be using `Rails.root` in dev of course and will use that value unless something else is specified. If using capistrano, you will want to define the base_path not including `current`. Biran will use this path to find the shared dir and the local config dir used to override any values.
 
 ### shared_dir
 **Type: string  
@@ -221,7 +221,7 @@ With the following config snippet as an example, you can use `@vhost[:host]` ins
 ```
 defaults: &defaults
   app: &app_defaults
-    root_path: <%= Rails.root %>
+    base_path: <%= Rails.root %>
     use_capistrano: false
     bindings:
       - db_config

--- a/lib/biran/config.rb
+++ b/lib/biran/config.rb
@@ -6,7 +6,7 @@ module Biran
 
     attr_writer :config_filename, :local_config_filename, :db_config_filename,
                 :secrets_filename, :config_dirname, :use_capistrano, :db_config,
-                :secrets, :root_path, :app_env, :base_dir, :bindings, :app_setup_blocks
+                :secrets, :base_path, :app_env, :base_dir, :bindings, :app_setup_blocks
 
     attr_accessor :shared_dir
 
@@ -67,10 +67,10 @@ module Biran
       @bindings ||= %i[db_config]
     end
 
-    def root_path
-      return @root_path if @root_path
-      @root_path = Rails.root if defined? Rails
-      @root_path ||= './'
+    def base_path
+      return @base_path if @base_path
+      @base_path = Rails.root if defined? Rails
+      @base_path ||= './'
     end
   end
 end

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -20,7 +20,7 @@ module Biran
     end
 
     def app_base
-      @app_base ||= ENV['APP_ROOT'] || app_config_defaults[:app][:root_path]
+      @app_base ||= ENV['BIRAN_APP_BASE'] || app_config_defaults[:app][:root_path]
     end
 
     def app_root
@@ -42,7 +42,7 @@ module Biran
     end
 
     def local_config_file
-      ENV['LOCAL_CONFIG_FILE'] ||
+      ENV['BIRAN_LOCAL_CONFIG_FILE'] ||
         File.join(app_shared_dir, configuration.config_dirname, configuration.local_config_filename)
     end
 

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -20,7 +20,7 @@ module Biran
     end
 
     def app_base
-      @app_base ||= ENV['BIRAN_APP_BASE'] || app_config_defaults[:app][:root_path]
+      @app_base ||= ENV['BIRAN_APP_BASE_PATH'] || app_config_defaults[:app][:base_path] || app_config_defaults[:app][:root_path]
     end
 
     def app_root

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -7,7 +7,7 @@ module Biran
     def app_defaults_init
       {
         app: {
-          root_path: configuration.root_path,
+          base_path: configuration.base_path,
           shared_dir: configuration.shared_dir,
           base_dir: configuration.base_dir,
           use_capistrano: configuration.use_capistrano,

--- a/spec/lib/biran/config_spec.rb
+++ b/spec/lib/biran/config_spec.rb
@@ -16,6 +16,6 @@ describe Biran::Config do
   it { is_expected.to respond_to :secrets }
   it { is_expected.to respond_to :app_setup_blocks }
   it { is_expected.to respond_to :bindings }
-  it { is_expected.to respond_to :root_path }
+  it { is_expected.to respond_to :base_path }
   it { is_expected.to respond_to :shared_dir }
 end

--- a/spec/lib/biran_spec.rb
+++ b/spec/lib/biran_spec.rb
@@ -13,9 +13,9 @@ describe Biran do
       expect(described_class.config.app_env).to eq 'test'
     end
 
-    it 'root_path is configurable' do
-      subject.configure { |config| config.root_path = 'path/to/root/' }
-      expect(described_class.config.root_path).to eq 'path/to/root/'
+    it 'base_path is configurable' do
+      subject.configure { |config| config.base_path = 'path/to/root/' }
+      expect(described_class.config.base_path).to eq 'path/to/root/'
     end
   end
 


### PR DESCRIPTION
Provide prefix for environment variables to namespace them to avoid conflicts.

Change config option for app_root to app_base to better reflect its purpose.