### PR TITLE
Missed two references to root_path in the default config, addresses #24

### DIFF
--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -38,7 +38,7 @@ module Biran
     end
 
     def config_dir
-      File.join configuration.root_path, configuration.config_dirname
+      File.join configuration.base_path, configuration.config_dirname
     end
 
     def local_config_file
@@ -51,7 +51,7 @@ module Biran
     end
 
     def secrets_file
-      File.join(configuration.root_path, configuration.config_dirname, configuration.secrets_filename)
+      File.join(configuration.base_path, configuration.config_dirname, configuration.secrets_filename)
     end
 
     def default_db_config_file


### PR DESCRIPTION
Not sure how this got missed first round as I tested the config in test app during last round of work. Should have been caught then.