### PR TITLE
Remove the defaults for files_to_geneate

### DIFF
--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -11,7 +11,6 @@ module Biran
           shared_dir: configuration.shared_dir,
           base_dir: configuration.base_dir,
           use_capistrano: configuration.use_capistrano,
-          files_to_generate: configuration.files_to_generate,
           db_config: configuration.db_config,
           secrets: configuration.secrets,
           bindings: configuration.bindings


### PR DESCRIPTION
- This removes the hash from being in the app_defaults array. This
caused a hash merge issue later when combined with the config file
values
- We pull in the defaults later in the function that is set to load the
list and use it.