### PR TITLE
Rails is now a conditional option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     biran (0.1.4)
+      activesupport
       railties
 
 GEM

--- a/biran.gemspec
+++ b/biran.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties"
+  s.add_dependency "activesupport"
   s.add_development_dependency "rails"
   s.add_development_dependency "bundler"
   s.add_development_dependency 'rspec'

--- a/lib/biran.rb
+++ b/lib/biran.rb
@@ -1,3 +1,6 @@
+require 'yaml'
+require 'erb'
+require 'active_support/core_ext/hash'
 require 'biran/config_defaults'
 require 'biran/config'
 require 'biran/erb_config'

--- a/lib/biran/config.rb
+++ b/lib/biran/config.rb
@@ -45,10 +45,11 @@ module Biran
     end
 
     def files_to_generate
-      {
-        vhost: {extension: '.conf'},
-        database: {extension: '.yml'}
-      }
+      { vhost: {extension: '.conf'} }
+    end
+
+    def db_file_to_generate
+      { database: { extension: '.yml' } }
     end
 
     def db_config

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -55,6 +55,9 @@ module Biran
     end
 
     def default_db_config_file
+      unless defined? Rails
+        return "#{app_defaults_init[:app][:base_path]}/#{configuration.config_dirname}/#{configuration.db_config_filename}"
+      end
       Rails.root.join(configuration.config_dirname, configuration.db_config_filename)
     end
 

--- a/lib/tasks/biran_tasks.rake
+++ b/lib/tasks/biran_tasks.rake
@@ -9,7 +9,7 @@ namespace :config do
 
   task :generate_with_deps
 
-  config.files_to_generate.each do |file_name, options|
+  config.config_files_to_generate.each do |file_name, options|
     desc %(Generate the #{file_name}#{options.fetch(:extension, '')} config file)
     task file_name do
       config.create name: file_name, **options


### PR DESCRIPTION
This PR adds checks for `Rails` definition in order to use the gem without it.

for this to work, there is the need to load the tasks manually in the `Rakefile` of the ruby project.
We should research on doing this **a priori**

current implementation sample Rakefile is like:

```
require 'bundler/setup'
require 'rake'
Bundler.require

# Load Biran Gem tasks
config = Gem::Specification.find_by_name('biran')
Dir["#{config.gem_dir}/lib/tasks/*.rake"].each do |file|
  Rake::load_rakefile(file)
end

$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
Dir.glob('lib/tasks/*.rake').each {|r| import r}
```

Also since we have by default creating `database.yml` this PR is a transition in this part as it will still create that by default. But if you add `db_config: false` to the `app_config.yml` file, under `defaults > app` the file and the task will be skipped