### PR TITLE
Remove Rails dependencies so gem will work in ruby apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     biran (0.1.5)
+      activesupport
       railties
 
 GEM

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ In a non-rails app, you will need to do some extra work to make the tasks availa
 Here is a minimal Rakefile for a basic ruby app that includes the biran tasks along with any local tasks in `lib/tasks`
 ```
 require 'bundler/setup'
-require 'biran'
+Bundler.require
 
-spec = Gem::Specification.find_by_name 'biran'
-load "#{spec.gem_dir}/lib/tasks/biran_tasks.rake"
+biran_gem = Gem::Specification.find_by_name 'biran'
+Dir["#{biran_gem.gem_dir}/lib/tasks/*.rake"].each do |file|
+  Rake::load_rakefile(file)
+end
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ That guy that creates the config files for every new proyect.
 
 This is a simple proof of concept on the configuration files we use in most of our rails/ruby projects.
 
-This version will look for an `app_config.yml` file on `config` folder in the project root.
+This version will look for an `app_config.yml` file in `config` folder in the project root.
 
 # TODO:
 
@@ -15,6 +15,25 @@ This version will look for an `app_config.yml` file on `config` folder in the pr
 - Add option for server config, right now only creates nginx vhost file and mysql database files for rails AR projects.
 - More stuff
 
+# Use
+In a rails app, simply include the gem in your Gemfile:
+```
+gem 'biran'
+```
+
+In a non-rails app, you will need to do some extra work to make the tasks available to rake. In your Rakefile you will need to manually include things.
+Here is a minimal Rakefile for a basic ruby app that includes the biran tasks along with any local tasks in `lib/tasks`
+```
+require 'bundler/setup'
+require 'biran'
+
+spec = Gem::Specification.find_by_name 'biran'
+load "#{spec.gem_dir}/lib/tasks/biran_tasks.rake"
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
+
+Dir.glob('lib/tasks/*.rake').each {|r| import r}
+```
 
 # Configuration
 
@@ -249,14 +268,13 @@ Generally not needed to configure, but available. Used to prevent defined top le
 Default:**  
 ```
 {
-  vhost: {extension: '.conf'},
-  database: {extension: '.yml'}
+  vhost: {extension: '.conf'}
 }
 ```  
 **Available in: config file, initializer**
 
 This config option defines which files you want to be available to generate as part of the config:generate task. Each file listed will get its own task and will be run when `rake config:generate` is run.
-The default config will generate `config/vhost.conf` and `config/database.yml`. By default, all files will be generated in the `config` directory. You can override this in the options.
+The default config will generate `config/vhost.conf` only. By default, all files will be generated in the `config` directory. You can override this in the options.
 Basic exmple from `config/app_config.yml`:
 ```
 app:

--- a/biran.gemspec
+++ b/biran.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties"
+  s.add_dependency "activesupport"
   s.add_development_dependency "rails"
   s.add_development_dependency "bundler"
   s.add_development_dependency 'rspec'

--- a/lib/biran.rb
+++ b/lib/biran.rb
@@ -1,3 +1,6 @@
+require 'yaml'
+require 'erb'
+require 'active_support/core_ext/hash'
 require 'biran/config_defaults'
 require 'biran/config'
 require 'biran/erb_config'

--- a/lib/biran/config.rb
+++ b/lib/biran/config.rb
@@ -46,8 +46,7 @@ module Biran
 
     def files_to_generate
       {
-        vhost: {extension: '.conf'},
-        database: {extension: '.yml'}
+        vhost: {extension: '.conf'}
       }
     end
 

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -54,7 +54,7 @@ module Biran
     end
 
     def default_db_config_file
-      Rails.root.join(configuration.config_dirname, configuration.db_config_filename)
+      File.join(config_dir, configuration.db_config_filename)
     end
 
     def use_capistrano?

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -121,7 +121,7 @@ module Biran
       lambda do |file, _|
         files_list[file] ||=  {extension: ''}
         ext = files_list[file].fetch(:extension, '').strip
-        ext.prepend('.') unless ext.starts_with?('.') || ext.empty?
+        ext.prepend('.') unless ext.start_with?('.') || ext.empty?
         files_list[file][:extension] = ext
       end
     end


### PR DESCRIPTION
This PR adds checks for `Rails` definition in order to use the gem without it. Based on work by @javierg in #36.

For this to work, there is the need to load the tasks manually in the `Rakefile` of the ruby project.
We should research on doing this **a priori**

current implementation sample Rakefile is like:

```
require 'bundler/setup'
require 'rake'
Bundler.require

# Load Biran Gem tasks
config = Gem::Specification.find_by_name('biran')
Dir["#{config.gem_dir}/lib/tasks/*.rake"].each do |file|
  Rake::load_rakefile(file)
end

$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
Dir.glob('lib/tasks/*.rake').each {|r| import r}
```
