### PR TITLE
Force shared_path in vhost directories to be a string

### DIFF
--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -97,7 +97,7 @@ module Biran
     def config_vhost_dirs
       {
         public_dir: File.join(app_root, 'public'),
-        shared_dir: app_shared_dir,
+        shared_dir: app_shared_dir.to_s,
         log_dir: File.join(app_root, 'log'),
         pids_dir: File.join(app_root, 'tmp', 'pids')
       }


### PR DESCRIPTION
- The rest of the paths in this block are converted to strings using the
File.join pattern.
- Shows up when including the vhost block in settings