### PR TITLE
Allow an alternate name for generated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ Default:**
 **Available in: config file, initializer**
 
 This config option defines which files you want to be available to generate as part of the config:generate task. Each file listed will get its own task and will be run when `rake config:generate` is run.
-The default config will generate `config/vhost.conf` only. By default, all files will be generated in the `config` directory. You can override this in the options by setting an `output_dir` and/or an `output_name` to define the location and the name to be added to the extension.
-NOTE: If you use the `output_name` option, the template name is still pulled from the block name. In the example below, for the reports file, the template name would be `config/_reports.yml.erb` and the block will genearte a file in `/srv/app/current/reports` named `user_report.yml`.
+The default config will generate `config/vhost.conf` only. By default, all files will be generated in the `config` directory. You can override this in the options by setting an `output_dir` and/or an `output_name` to define the location and the name to be added to the extension.  
+NOTE: If you use the `output_name` option, the template name is still pulled from the block name. In the example below, for the reports file, the template name would be `config/_reports.yml.erb` and the block will generate a file in `/srv/app/current/reports` named `user_report.yml`.  
 Basic exmple from `config/app_config.yml`:
 ```
 app:

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ Default:**
 **Available in: config file, initializer**
 
 This config option defines which files you want to be available to generate as part of the config:generate task. Each file listed will get its own task and will be run when `rake config:generate` is run.
-The default config will generate `config/vhost.conf` only. By default, all files will be generated in the `config` directory. You can override this in the options.
+The default config will generate `config/vhost.conf` only. By default, all files will be generated in the `config` directory. You can override this in the options by setting an `output_dir` and/or an `output_name` to define the location and the name to be added to the extension.
+NOTE: If you use the `output_name` option, the template name is still pulled from the block name. In the example below, for the reports file, the template name would be `config/_reports.yml.erb` and the block will genearte a file in `/srv/app/current/reports` named `user_report.yml`.
 Basic exmple from `config/app_config.yml`:
 ```
 app:
@@ -291,6 +292,7 @@ app:
     reports:
       extension: ‘.yml’
       output_dir: ‘/srv/app/current/reports’
+      output_name: ‘user_report’
 ```
 ### vhost_public_dirname
 **Type: string  

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -39,9 +39,10 @@ module Biran
         .tap { |files_list| files_list.each(&sanitize_config_files(files_list)) }
     end
 
-    def create(name:, extension:, output_dir: nil)
+    def create(name:, extension:, output_dir: nil, output_name: nil)
       output_dir ||= config_dir
-      generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir)
+      output_name ||= name
+      generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
       generated_file.bindings = bindings
       generated_file.save!
     end

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -1,18 +1,19 @@
 module Biran
   class ERBConfig
-    attr_reader :output_dir, :source_dir, :name, :extension, :config
+    attr_reader :output_dir, :source_dir, :name, :extension, :config, :output_name
     attr_accessor :bindings
 
-    def initialize(config, name, extension, source, output)
+    def initialize(config, name, extension, source, output_dir, output_name)
       @name       = name
       @extension  = extension
       @config     = config
       @source_dir = source
-      @output_dir = output
+      @output_dir = output_dir
+      @output_name = output_name
     end
 
     def save!
-      File.open(File.join(output_dir, "#{name}#{extension}"), 'w') do |f|
+      File.open(File.join(output_dir, "#{output_name}#{extension}"), 'w') do |f|
         f.print process_erb.result(build_erb_env.call)
       end
     end


### PR DESCRIPTION
Allows user to generate a second file with same name but in a different location.