### PR TITLE
Allow secrets block in app_config.yml to actually be used

### DIFF
--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -53,7 +53,7 @@ module Biran
       }
 
       app_config.deep_merge! app_config_defaults
-      app_config[:secrets] = get_secret_contents(app_config)
+      app_config[:secrets].deep_merge! get_secret_contents(app_config)
       app_config[:db_config] = build_db_config
 
       app_config.deep_merge! local_config_file_contents


### PR DESCRIPTION
- Previously, biran would wipe out any values from app_config.yml when
loading contents of secrets file, even if there was no secrets file.
- This drops the need for the secrets file provide default values.