### PR TITLE
Refactor the config build process to actually use defaults from configuration object

### DIFF
--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -11,11 +11,11 @@ module Biran
           shared_dir: configuration.shared_dir,
           base_dir: configuration.base_dir,
           use_capistrano: configuration.use_capistrano,
-          db_config: configuration.db_config,
-          secrets: configuration.secrets,
           bindings: configuration.bindings,
           vhost_public_dirname: configuration.vhost_public_dirname
-        }
+        },
+        db_config: configuration.db_config,
+        secrets: configuration.secrets,
       }
     end
 

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -104,11 +104,8 @@ module Biran
     end
 
     def get_secrets_content(secrets_file)
-      secrets_file_contents = {}
-      if File.exist? secrets_file
-        secrets_file_contents = process_config_file secrets_file
-      end
-      secrets_file_contents
+      return {} unless File.exists? secrets_file
+      process_config_file secrets_file
     end
 
     def sanitize_config_files files_list

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -53,8 +53,8 @@ module Biran
       }
 
       app_config.deep_merge! app_config_defaults
-      app_config[:secrets].deep_merge! get_secret_contents(app_config)
-      app_config[:db_config] = build_db_config
+      app_config[:secrets].deep_merge! get_secrets_content(app_config[:secrets_file_path])
+      app_config[:db_config].deep_merge! build_db_config
 
       app_config.deep_merge! local_config_file_contents
     end
@@ -103,10 +103,10 @@ module Biran
       @local_config_contents = process_config_file(local_config_file)
     end
 
-    def get_secret_contents(app_config)
+    def get_secrets_content(secrets_file)
       secrets_file_contents = {}
-      if File.exist? app_config[:secrets_file_path]
-        secrets_file_contents = process_config_file app_config[:secrets_file_path]
+      if File.exist? secrets_file
+        secrets_file_contents = process_config_file secrets_file
       end
       secrets_file_contents
     end


### PR DESCRIPTION
Previously, we were ignoring any values set for secrets or db_config if you set them via `Biran.configure`. The build app_config process would only pull in values from the app_config.yml file or any local override file.

No functionality should have changed except we now enforce the configuration --> app_config.yml --> local_config override priority that is used in other things. We were skipping that first part.