### PR TITLE
Re-use erb template to generate multiple copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,39 @@ app:
       extension: ‘.yml’
       output_dir: ‘/srv/app/current/reports’
       output_name: ‘user_report’
+```  
+
+In a more advanced example, you can generate multiple files from the same template by setting the `config_index_list` option. If you set this as a list of indexes, then a file will be generated for each index. The index number 
+will get passed to the template as an instance variable (`@config_index`) and can be used to look up a specific version of values from the config file. The file that is generated will respect the normal naming, including using the `output_name` option, however, it will append the 
+index number to the end of the file name. If the name was going to be special_file, and you add an index list of `[1,2]`, two files will get generated named `special_file-1` and `special_file-2`.  
+Advanced example from `config/app:.yml`:
 ```
+app:
+  files_to_generate:
+    reports:
+      extension: '.yml'
+      config_index_list:
+        - one
+        - two
+reports:
+  default: &reports_default_values
+    some_value: 'some_value'
+    other_value: 'other_value'
+  one:
+    <<: *reports_default_values
+  two:
+    <<: *reports_default_values
+    some_value: 'my_value'
+```  
+Then in your template file you can use the index to get the proper config for each generated file. This allows you to reuse the same template to generate multiple files, each with different content. This is useful for generating service config files, like for sidekiq workers.
+The config above would generate two files: `config/reports-one.yml` and `config/reports-two.yml`, using the content from each index block as specified in the following simple template example.
+```
+<% index = "{@config_index}" -%>
+defaults:
+  :some_value: <%= @app_config[:reports][index.to_sym][:some_value] %>
+  :other_value: <%= @app_config[:reports][index.to_sym][:other_value] %>
+```  
+
 ### vhost_public_dirname
 **Type: string  
 Default: 'public'  

--- a/lib/biran.rb
+++ b/lib/biran.rb
@@ -5,6 +5,7 @@ require 'biran/config_defaults'
 require 'biran/config'
 require 'biran/erb_config'
 require 'biran/configurinator'
+require 'biran/exceptions'
 require 'biran/railtie' if defined?(Rails)
 
 module Biran

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -31,20 +31,15 @@ module Biran
     end
 
     def create(name:, extension:, output_dir: nil, output_name: nil, config_index_list: [])
-      begin
-        output_dir ||= config_dir
-        output_name ||= name
-        generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
-        generated_file.bindings = bindings
-        return generated_file.save! unless config_index_list.any?
-        config_index_list.each do |config_index|
-          generated_file.output_name = "#{output_name}-#{config_index}"
-          generated_file.template_config_index = config_index
-          generated_file.save!
-        end
-      rescue ArgumentError => e
-        puts 'Missing required argument or bad syntax in config file'
-        puts e
+      output_dir ||= config_dir
+      output_name ||= name
+      generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
+      generated_file.bindings = bindings
+      return generated_file.save! unless config_index_list.any?
+      config_index_list.each do |config_index|
+        generated_file.output_name = "#{output_name}-#{config_index}"
+        generated_file.template_config_index = config_index
+        generated_file.save!
       end
     end
 

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -31,15 +31,20 @@ module Biran
     end
 
     def create(name:, extension:, output_dir: nil, output_name: nil, config_index_list: [])
-      output_dir ||= config_dir
-      output_name ||= name
-      generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
-      generated_file.bindings = bindings
-      return generated_file.save! unless config_index_list.any?
-      config_index_list.each do |config_index|
-        generated_file.output_name = "#{output_name}-#{config_index}"
-        generated_file.template_config_index = config_index
-        generated_file.save!
+      begin
+        output_dir ||= config_dir
+        output_name ||= name
+        generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
+        generated_file.bindings = bindings
+        return generated_file.save! unless config_index_list.any?
+        config_index_list.each do |config_index|
+          generated_file.output_name = "#{output_name}-#{config_index}"
+          generated_file.template_config_index = config_index
+          generated_file.save!
+        end
+      rescue ArgumentError => e
+        puts 'Missing required argument or bad syntax in config file'
+        puts e
       end
     end
 

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -30,12 +30,17 @@ module Biran
         .tap { |files_list| files_list.each(&sanitize_config_files(files_list)) }
     end
 
-    def create(name:, extension:, output_dir: nil, output_name: nil)
+    def create(name:, extension:, output_dir: nil, output_name: nil, config_index_list: [])
       output_dir ||= config_dir
       output_name ||= name
       generated_file = ERBConfig.new(filtered_config, name, extension, config_dir, output_dir, output_name)
       generated_file.bindings = bindings
-      generated_file.save!
+      return generated_file.save! unless config_index_list.any?
+      config_index_list.each do |config_index|
+        generated_file.output_name = "#{output_name}-#{config_index}"
+        generated_file.config_index = config_index
+        generated_file.save!
+      end
     end
 
     private

--- a/lib/biran/configurinator.rb
+++ b/lib/biran/configurinator.rb
@@ -38,7 +38,7 @@ module Biran
       return generated_file.save! unless config_index_list.any?
       config_index_list.each do |config_index|
         generated_file.output_name = "#{output_name}-#{config_index}"
-        generated_file.config_index = config_index
+        generated_file.template_config_index = config_index
         generated_file.save!
       end
     end

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -6,13 +6,14 @@ module Biran
     DEFAULT_TEMPLATE_CONFIG_INDEX = 1
 
     def initialize(config, name, extension, source, output_dir, output_name)
-      @name       = name
-      @extension  = extension
-      @config     = config
-      @source_dir = source
-      @output_dir = output_dir
-      @output_name = output_name
-      @template_contents = process_erb
+      before_process_erb do
+        @name       = name
+        @extension  = extension
+        @config     = config
+        @source_dir = source
+        @output_dir = output_dir
+        @output_name = output_name
+      end
     end
 
     def save!
@@ -22,6 +23,26 @@ module Biran
     end
 
     private
+
+    def before_process_erb
+      yield
+      begin
+        process_erb_ready?
+      rescue ArgumentError => e
+        puts 'Settings required to determine template name are not configured'
+        puts e
+        exit
+      end
+      @template_contents = process_erb
+    end
+
+    def process_erb_ready?
+      error_text = "Missing argument: %s for #{name} block"
+      raise ArgumentError.new(error_text % 'name') unless @name
+      raise ArgumentError.new(error_text % 'extension') unless @extension
+      raise ArgumentError.new(error_text % 'source_dir') unless @source_dir
+      true
+    end
 
     def process_erb
       config_erb_file = File.join(source_dir, "_#{name}#{extension}.erb")

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -1,9 +1,9 @@
 module Biran
   class ERBConfig
     attr_reader :output_dir, :source_dir, :name, :extension, :config, :template_contents
-    attr_accessor :bindings, :output_name, :config_index
+    attr_accessor :bindings, :output_name, :template_config_index
 
-    DEFAULT_CONFIG_INDEX = 1
+    DEFAULT_TEMPLATE_CONFIG_INDEX = 1
 
     def initialize(config, name, extension, source, output_dir, output_name)
       @name       = name
@@ -32,7 +32,7 @@ module Biran
       proc do
         @environment = config[:env]
         @app_config  = config
-        @config_index =  config_index || DEFAULT_CONFIG_INDEX
+        @config_index =  template_config_index || DEFAULT_TEMPLATE_CONFIG_INDEX
 
         @bindings.each(&assign_instance_vars) unless @bindings.nil?
 

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -1,7 +1,9 @@
 module Biran
   class ERBConfig
-    attr_reader :output_dir, :source_dir, :name, :extension, :config, :output_name
-    attr_accessor :bindings
+    attr_reader :output_dir, :source_dir, :name, :extension, :config, :template_contents
+    attr_accessor :bindings, :output_name, :config_index
+
+    DEFAULT_CONFIG_INDEX = 1
 
     def initialize(config, name, extension, source, output_dir, output_name)
       @name       = name
@@ -10,11 +12,12 @@ module Biran
       @source_dir = source
       @output_dir = output_dir
       @output_name = output_name
+      @template_contents = process_erb
     end
 
     def save!
       File.open(File.join(output_dir, "#{output_name}#{extension}"), 'w') do |f|
-        f.print process_erb.result(build_erb_env.call)
+        f.print template_contents.result(build_erb_env.call)
       end
     end
 
@@ -29,6 +32,7 @@ module Biran
       proc do
         @environment = config[:env]
         @app_config  = config
+        @config_index =  config_index || DEFAULT_CONFIG_INDEX
 
         @bindings.each(&assign_instance_vars) unless @bindings.nil?
 

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -45,8 +45,13 @@ module Biran
     end
 
     def process_erb
-      config_erb_file = File.join(source_dir, "_#{name}#{extension}.erb")
-      ERB.new(File.read(config_erb_file), nil, '-')
+      begin
+        config_erb_file = File.join(source_dir, "_#{name}#{extension}.erb")
+        ERB.new(File.read(config_erb_file), nil, '-')
+      rescue Errno::ENOENT
+        puts "Missing template file #{config_erb_file}"
+        exit
+      end
     end
 
     def build_erb_env

--- a/lib/biran/exceptions.rb
+++ b/lib/biran/exceptions.rb
@@ -1,7 +1,7 @@
 module Biran
   class ConfigSyntaxError < ::StandardError
-    def initialize(msg='Missing required argument or bad formatting in config file')
-      @msg = msg
+    def initialize(msg=nil)
+      @msg = msg || 'Missing required argument or bad formatting in config file'
       set_backtrace []
     end
 

--- a/lib/biran/exceptions.rb
+++ b/lib/biran/exceptions.rb
@@ -1,0 +1,16 @@
+module Biran
+  class ConfigSyntaxError < ::StandardError
+    def initialize(msg='Missing required argument or bad formatting in config file')
+      @msg = msg
+      set_backtrace []
+    end
+
+    def to_s
+      @msg
+    end
+
+    def p_warning
+      "Warning: #{@msg}"
+    end
+  end
+end

--- a/lib/tasks/biran_tasks.rake
+++ b/lib/tasks/biran_tasks.rake
@@ -7,17 +7,32 @@ namespace :config do
     Rake::Task['config:generate_with_deps'].invoke
   end
 
+  task :generate2 do
+    error_count = 0
+    config.file_tasks.each do |task|
+      Rake::Task["config:#{task}"].invoke
+    rescue Biran::ConfigSyntaxError => e
+      error_count += 1
+      puts e.p_warning
+      next
+    end
+
+    abort 'Errors in creating config files' unless error_count == 0
+    return
+  end
   task :generate_with_deps
 
   config.files_to_generate.each do |file_name, options|
     desc %(Generate the #{file_name}#{options.fetch(:extension, '')} config file)
     task file_name do
-      begin
-       config.create name: file_name, **options
-      rescue ArgumentError => e
-        puts 'Missing required argument or bad formatting in config file'
-        puts e
-      end
+      config.create name: file_name, **options
+    rescue ArgumentError => e
+      e_message = "Missing required argument or bad formatting in config file for #{file_name}"
+      e.set_backtrace([])
+      raise Biran::ConfigSyntaxError, e_message
+    rescue Biran::ConfigSyntaxError => e
+      e.set_backtrace([])
+      raise Biran::ConfigSyntaxError, e.message
     end
   end
 

--- a/lib/tasks/biran_tasks.rake
+++ b/lib/tasks/biran_tasks.rake
@@ -1,13 +1,16 @@
 namespace :config do
   config = Biran::Configurinator.new
 
-  desc 'Generate new config files'
-  task :generate do
+  desc 'Legacy - Generate all new config files'
+  task :generate_legacy do
     Rake::Task['config:generate_with_deps'].enhance config.file_tasks
     Rake::Task['config:generate_with_deps'].invoke
   end
 
-  task :generate2 do
+  task :generate_with_deps
+
+  desc 'Generate all new config files'
+  task :generate do
     error_count = 0
     config.file_tasks.each do |task|
       Rake::Task["config:#{task}"].invoke
@@ -19,7 +22,6 @@ namespace :config do
 
     abort 'Errors in creating config files' unless error_count == 0
   end
-  task :generate_with_deps
 
   config.files_to_generate.each do |file_name, options|
     desc %(Generate the #{file_name}#{options.fetch(:extension, '')} config file)

--- a/lib/tasks/biran_tasks.rake
+++ b/lib/tasks/biran_tasks.rake
@@ -18,7 +18,6 @@ namespace :config do
     end
 
     abort 'Errors in creating config files' unless error_count == 0
-    return
   end
   task :generate_with_deps
 

--- a/lib/tasks/biran_tasks.rake
+++ b/lib/tasks/biran_tasks.rake
@@ -12,7 +12,12 @@ namespace :config do
   config.files_to_generate.each do |file_name, options|
     desc %(Generate the #{file_name}#{options.fetch(:extension, '')} config file)
     task file_name do
-      config.create name: file_name, **options
+      begin
+       config.create name: file_name, **options
+      rescue ArgumentError => e
+        puts 'Missing required argument or bad formatting in config file'
+        puts e
+      end
     end
   end
 


### PR DESCRIPTION
- ERBConfig creates an instance of the template and we pass in a
separate config index number that can be used to pull different values
from different parts of the config block passed to the template
- If no list of config indexes is passed, we retain current, previous
behaviour.

This allows things like generating multiple copies of sidekiq config files using the same template, but having the template pull different values from the passed in config block. So each file would use a different config index number and reference that in the `@app_config` instance variable for that iteration of the template output.
This way shaved about a half second off my test run against the bs repo when generating 3 sidekiq files from three different `files_to_generate` entries down to just one with an index list. 

The goal in this approach was to save I/O time by having to load the same template file each time for multiple runs on the same template. The downside is that you are manipulating two of the instance variables for each output file. My argument is that we are treating the instance as an instance of the template, not an instance of the output file. Since the change happens in the loop, and each loop run changes the same instance variables, there is no hold over from the previous "run" that might corrupt the instance. Also, the values will not corrupt the other files being generated from different templates as they are different instances of ERBConfig.

Address: #54 