### PR TITLE
Allow config file names to be passed in app_config

### DIFF
--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -55,7 +55,11 @@ module Biran
     end
 
     def db_config_override_file
-      File.join(app_shared_dir, configuration.config_dirname, configuration.db_config_filename)
+      File.join(app_shared_dir, configuration.config_dirname, db_config_filename)
+    end
+
+    def db_config_filename
+       app_config_defaults[:app][:db_config_file_name] || configuration.db_config_filename
     end
 
     def secrets_file
@@ -63,7 +67,7 @@ module Biran
     end
 
     def default_db_config_file
-      File.join(config_dir, configuration.db_config_filename)
+      File.join(config_dir, db_config_filename)
     end
 
     def use_capistrano?

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -47,7 +47,11 @@ module Biran
 
     def local_config_file
       ENV['BIRAN_LOCAL_CONFIG_FILE'] ||
-        File.join(app_shared_dir, configuration.config_dirname, configuration.local_config_filename)
+        File.join(app_shared_dir, configuration.config_dirname, local_config_filename)
+    end
+
+    def local_config_filename
+      ENV['BIRAN_LOCAL_CONFIG_FILENAME'] || app_config_defaults[:app][:local_config_filename] || configuration.local_config_filename
     end
 
     def vhost_public_dirname

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -63,7 +63,11 @@ module Biran
     end
 
     def secrets_file
-      File.join(configuration.base_path, configuration.config_dirname, configuration.secrets_filename)
+      File.join(configuration.base_path, configuration.config_dirname, secrets_filename)
+    end
+
+    def secrets_filename
+      app_config_defaults[:app][:secrets_filename] || configuration.secrets_filename
     end
 
     def default_db_config_file

--- a/lib/biran/config_defaults.rb
+++ b/lib/biran/config_defaults.rb
@@ -63,7 +63,7 @@ module Biran
     end
 
     def db_config_filename
-       app_config_defaults[:app][:db_config_file_name] || configuration.db_config_filename
+       app_config_defaults[:app][:db_config_filename] || configuration.db_config_filename
     end
 
     def secrets_file


### PR DESCRIPTION
The readme says and we expected to be able to change the names of the db_config, local_config and secrets files from app_config, as well as from other places. We were ignoring them if set in app_config.

The only change here is really checking to see if its is set in app_config and then using it if it is, otherwise, use the defaults, which had been using.