### PR TITLE
Change ERB.new call to use named arguements

### DIFF
--- a/biran.gemspec
+++ b/biran.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Helper for generating config generate tasks."
   s.description = "Biran is the guy that will help you generate config files for your rail app."
   s.license     = "MIT"
+  s.required_ruby_version = ">= 2.6.0"
 
   s.metadata = {
     "rubygems_mfa_required" => "true",

--- a/lib/biran/erb_config.rb
+++ b/lib/biran/erb_config.rb
@@ -41,7 +41,7 @@ module Biran
 
     def process_erb
       config_erb_file = File.join(source_dir, "_#{name}#{extension}.erb")
-      ERB.new(File.read(config_erb_file), nil, '-')
+      ERB.new(File.read(config_erb_file), trim_mode: '-')
     rescue Errno::ENOENT
       raise Biran::ConfigSyntaxError, "Missing template file for #{name}: #{config_erb_file}"
     end


### PR DESCRIPTION
- Fixes depreciation warning about passing positional arguments. ERB depreciated them in recent releases and prefer the named arguments