### PR TITLE
Bump version to 0.2.0 for new release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    biran (0.1.15)
+    biran (0.2.0)
       activesupport (>= 5.0.7)
       railties (>= 5.0.7)
 

--- a/lib/biran/version.rb
+++ b/lib/biran/version.rb
@@ -1,3 +1,3 @@
 module Biran
-  VERSION = '0.1.15'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
- Add support for ruby 3.2
- This drops support for ruby less than 2.7 due to requirements in ruby 3.2 and related gems.